### PR TITLE
libsystemd: add id128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ exclude = [
 
 [dependencies]
 error-chain = { version = "0.12", default-features = false }
+hmac = "0.7"
 libc = "0.2"
 nix = "0.13"
+sha2 = "0.8"
 try_or = "0.2"
+uuid = "0.7"
 
 [dev-dependencies]
 quickcheck = "0.7"

--- a/examples/notify.rs
+++ b/examples/notify.rs
@@ -1,7 +1,7 @@
 extern crate libsystemd;
 
-use std::{env, thread};
 use libsystemd::daemon::{self, NotifyState};
+use std::{env, thread};
 
 /*
 cargo build --example notify

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,7 +1,7 @@
 extern crate libsystemd;
 
-use std::thread;
 use libsystemd::daemon::{self, NotifyState};
+use std::thread;
 
 /*
 ```

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,7 @@
-use std::{env, fmt, fs, path, time};
-use std::os::unix::net::UnixDatagram;
 use libc::pid_t;
 use nix::unistd;
+use std::os::unix::net::UnixDatagram;
+use std::{env, fmt, fs, path, time};
 
 use errors::*;
 
@@ -68,9 +68,9 @@ pub fn notify(unset_env: bool, state: &[NotifyState]) -> Result<bool> {
     };
     let sock = UnixDatagram::unbound()?;
 
-    let msg = state.iter().fold(String::new(), |res, s| {
-        res + &format!("{}\n", s)
-    });
+    let msg = state
+        .iter()
+        .fold(String::new(), |res, s| res + &format!("{}\n", s));
     let msg_len = msg.len();
     let sent_len = sock.send_to(msg.as_bytes(), path)?;
     if sent_len != msg_len {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-error_chain!{
+error_chain! {
     foreign_links {
         Io(::std::io::Error);
     }

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -1,0 +1,83 @@
+use errors::*;
+use std::fs;
+use std::io::Read;
+use uuid::Uuid;
+
+/// A 128-bits ID.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Id128 {
+    uuid_v4: Uuid,
+}
+
+impl Id128 {
+    /// Parse an `Id128` from string.
+    pub fn parse_str<S>(input: S) -> Result<Self>
+    where
+        S: AsRef<str>,
+    {
+        let uuid_v4 = Uuid::parse_str(input.as_ref()).map_err(|_| "failed to parse from string")?;
+        Ok(Self { uuid_v4 })
+    }
+
+    /// Hash this ID with an application-specific ID.
+    pub fn app_specific(&self, app: &Self) -> Result<Self> {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let mut mac = Hmac::<Sha256>::new_varkey(self.uuid_v4.as_bytes())
+            .map_err(|_| "failed to prepare HMAC")?;
+        mac.input(app.uuid_v4.as_bytes());
+        let mut hashed = mac.result().code();
+
+        ensure!(hashed.len() == 32, "short hash");
+
+        // Set version to 4.
+        hashed[6] = (hashed[6] & 0x0F) | 0x40;
+        // Set variant to DCE.
+        hashed[8] = (hashed[8] & 0x3F) | 0x80;
+
+        let uuid_v4 = Uuid::from_slice(&hashed[..16]).map_err(|_| "failed to parse bytes")?;
+
+        Ok(Id128 { uuid_v4 })
+    }
+}
+
+/// Return this machine unique ID.
+pub fn get_machine() -> Result<Id128> {
+    let mut buf = String::new();
+    let mut fd = fs::File::open("/etc/machine-id")?;
+    fd.read_to_string(&mut buf)?;
+    Id128::parse_str(buf.trim_right())
+}
+
+/// Return this machine unique ID, hashed with an application-specific ID.
+pub fn get_machine_app_specific(app_id: &Id128) -> Result<Id128> {
+    let machine_id = get_machine()?;
+    machine_id.app_specific(app_id)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic_parse_str() {
+        let input = "2e074e9b299c41a59923c51ae16f279b";
+        Id128::parse_str(input).unwrap();
+    }
+
+    #[test]
+    fn basic_keyed_hash() {
+        let input = "2e074e9b299c41a59923c51ae16f279b";
+        let machine_id = Id128::parse_str(input).unwrap();
+
+        let key = "033b1b9b264441fcaa173e9e5bf35c5a";
+        let app_id = Id128::parse_str(key).unwrap();
+
+        let expected = "4d4a86c9c6644a479560ded5d19a30c5";
+        let hashed_id = Id128::parse_str(expected).unwrap();
+
+        let output = machine_id.app_specific(&app_id).unwrap();
+        assert_eq!(output, hashed_id);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,13 @@
 
 #[macro_use]
 extern crate error_chain;
+extern crate hmac;
 extern crate libc;
 extern crate nix;
+extern crate sha2;
 #[macro_use]
 extern crate try_or;
+extern crate uuid;
 
 #[cfg(test)]
 #[macro_use]
@@ -40,3 +43,6 @@ pub mod errors;
 
 /// Helpers for working with systemd units.
 pub mod unit;
+
+/// APIs for processing 128-bits IDs.
+pub mod id128;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -4,7 +4,8 @@ pub fn escape_name(name: &str) -> String {
         return "".to_string();
     }
 
-    let parts: Vec<String> = name.bytes()
+    let parts: Vec<String> = name
+        .bytes()
         .enumerate()
         .map(|(n, b)| escape_byte(b, n))
         .collect();


### PR DESCRIPTION
This adds a module for handling 128-bits IDs. See `sd-id128(3)`.