### PR TITLE
id128: add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,15 @@ exclude = [
 ]
 
 [dependencies]
-error-chain = { version = "0.12", default-features = false }
+error-chain = { version = "^0.12.1", default-features = false }
 hmac = "0.7"
 libc = "0.2"
 nix = "0.13"
 sha2 = "0.8"
 try_or = "0.2"
-uuid = "0.7"
+uuid = { version = "^0.7.4", features = ["serde"] }
+serde = "^1.0.91"
+serde_derive = "^1.0.91"
 
 [dev-dependencies]
 quickcheck = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ extern crate error_chain;
 extern crate hmac;
 extern crate libc;
 extern crate nix;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate sha2;
 #[macro_use]
 extern crate try_or;


### PR DESCRIPTION
This adds serialization and deserialization support for `Id128`.