### PR TITLE
Add support for reading from the system journal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ error-chain = { version = "^0.12.1", default-features = false }
 hmac = "0.7"
 libc = "0.2"
 nix = "0.15"
+sdjournal = { git = "https://github.com/jabedude/sdjournal-rs" }
 serde = { version = "^1.0.91", features = ["derive"] }
 sha2 = "0.8"
 uuid = { version = "^0.8.1", features = ["serde"] }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,57 @@
+use std::fs::File;
+use std::path::Path;
+
+use sdjournal::journal::*;
+use sdjournal::iter::EntryIter;
+
+use crate::errors::*;
+
+#[derive(Debug)]
+pub struct SdJournal {
+    inner: Journal<File>,
+}
+
+impl SdJournal {
+    pub fn open_journal<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let file = File::open(path)?;
+
+        let journal = Journal::new(file)?;
+
+        let sdjournal = SdJournal {
+            inner: journal,
+        };
+
+        Ok(sdjournal)
+    }
+
+    pub fn iter(&self) -> EntryIter<File> {
+        self.inner.iter_entries()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sdjournal_read_simple() {
+        let sd = SdJournal::open_journal("./tests/user-1000.journal");
+        assert!(sd.is_ok());
+    }
+
+    #[test]
+    fn test_sdjournal_iter_simple() {
+        let sd = SdJournal::open_journal("./tests/user-1000.journal").unwrap();
+
+        let mut counter = 0;
+
+        let iter = sd.iter();
+        for _obj in iter {
+            counter += 1;
+            //eprintln!("obj: {}", obj.realtime);
+        }
+
+        // journalctl --header --file tests/user-1000.journal | grep "Entry Objects" == 645
+        assert_eq!(counter, 645);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ pub mod activation;
 /// Interfaces for systemd-aware daemons.
 pub mod daemon;
 
+/// Interfaces for reading from the system journal.
+pub mod journal;
+
 /// Error handling.
 pub mod errors;
 


### PR DESCRIPTION
Closes #39.

This is a draft PR for adding support for reading from systemd's journal in pure rust.