### PR TITLE
ci: update travis and run on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,42 @@
+---
 language: rust
+os: linux
 
-rust:
-  - 1.39.0  # minimum supported toolchain
-  - 1.42.0  # pinned toolchain for clippy
-  - stable
-  - beta
-  - nightly
-
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
-
-env:
-  global:
-    - CLIPPY_RUST_VERSION=1.42.0
-
-before_script:
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      rustup component add clippy;
-    fi'
-
-script:
-  - cargo test
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo clippy -- -D warnings;
-    fi'
+  include:
+    - name: "Test with nightly toolchain"
+      arch: amd64
+      rust: nightly
+      script:
+        - cargo test
+    - name: "Test with stable toolchain"
+      arch: amd64
+      rust: stable
+      script:
+        - cargo test
+    - name: "Test with beta toolchain"
+      arch: amd64
+      rust: beta
+      script:
+        - cargo test
+    - name: "Test a secondary architecture (aarch64)"
+      arch: arm64
+      rust: stable
+      script:
+        - cargo test
+    - name: "Test with minimum supported toolchain"
+      arch: amd64
+      rust: 1.39.0
+      script:
+        - cargo test --release
+    - name: "Lints with pinned toolchain"
+      arch: amd64
+      rust: 1.43.0
+      before_script:
+        - rustup component add clippy
+        - rustup component add rustfmt
+      script:
+        - cargo clippy -- -D warnings
+        - cargo fmt -- --check -l

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libsystemd
 
-[![Build Status](https://travis-ci.org/lucab/libsystemd-rs.svg?branch=master)](https://travis-ci.org/lucab/libsystemd-rs)
+[![Build Status](https://travis-ci.com/lucab/libsystemd-rs.svg?branch=master)](https://travis-ci.com/lucab/libsystemd-rs)
 [![crates.io](https://img.shields.io/crates/v/libsystemd.svg)](https://crates.io/crates/libsystemd)
 [![LoC](https://tokei.rs/b1/github/lucab/libsystemd-rs?category=code)](https://github.com/lucab/libsystemd-rs)
 [![Documentation](https://docs.rs/libsystemd/badge.svg)](https://docs.rs/libsystemd)


### PR DESCRIPTION
This refreshes Travis configuration and adds a job to check non-x86
architectures (arm64).