### PR TITLE
errors: switch to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsystemd"
-version = "0.2.2-alpha.0"
-authors = ["Luca Bruno <lucab@debian.org>"]
+version = "0.3.0-alpha.0"
+authors = ["Luca Bruno <lucab@lucabruno.net>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"
 documentation = "https://docs.rs/libsystemd"
@@ -17,15 +17,15 @@ edition = "2018"
 
 [dependencies]
 error-chain = { version = "^0.12.1", default-features = false }
-hmac = "0.7"
-libc = "0.2"
-nix = "0.17"
+hmac = "^0.7"
+libc = "^0.2"
+nix = "^0.17"
 serde = { version = "^1.0.91", features = ["derive"] }
-sha2 = "0.8"
+sha2 = "^0.8"
 uuid = { version = "^0.8.1", features = ["serde"] }
 
 [dev-dependencies]
-quickcheck = "0.9"
+quickcheck = "^0.9"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ libc = "^0.2"
 nix = "^0.17"
 serde = { version = "^1.0.91", features = ["derive"] }
 sha2 = "^0.8"
+thiserror = "^1.0"
 uuid = { version = "^0.8.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ exclude = [
 edition = "2018"
 
 [dependencies]
-error-chain = { version = "^0.12.1", default-features = false }
 hmac = "^0.7"
 libc = "^0.2"
 nix = "^0.17"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,18 @@
-#![allow(deprecated)]
+use thiserror::Error;
 
-error_chain::error_chain! {
-    foreign_links {
-        Io(::std::io::Error);
-        Env(::std::env::VarError);
-        Ffi(::std::ffi::NulError);
-        Nix(nix::Error);
-        Parse(::std::num::ParseIntError);
+/// Library errors.
+#[derive(Error, Debug)]
+#[error("libsystemd error: {0}")]
+pub struct SdError(pub(crate) String);
+
+impl From<&str> for SdError {
+    fn from(arg: &str) -> Self {
+        Self(arg.to_string())
+    }
+}
+
+impl From<String> for SdError {
+    fn from(arg: String) -> Self {
+        Self(arg)
     }
 }


### PR DESCRIPTION
This drops `error-chain` usage in favor of `thiserror`. Due to public types change, this needs a minor  version bump.