### PR TITLE
activation: do not discard unknown descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 [dependencies]
 hmac = "^0.7"
 libc = "^0.2"
+log = "^0.4"
 nix = "^0.17"
 serde = { version = "^1.0.91", features = ["derive"] }
 sha2 = "^0.8"


### PR DESCRIPTION
This tweaks FD-receiving logic to account for file descriptors of an
unknown type (possibly invalid, too).
Previously this library would just halt and catch fire upon encountering
a single FD for which type-detection failed It now logs a warning message
but keeps the FD internally in a dedicated "unknown" variant, allowing
consumers to recover it and further try to process in some way.

Closes: https://github.com/lucab/libsystemd-rs/issues/46