### PR TITLE
logging: Derive Copy & Clone for Priority

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -19,7 +19,7 @@ pub static SD_JOURNAL_SOCK_PATH: &str = "/run/systemd/journal/socket";
 /// Log priority values.
 ///
 /// See `man 3 syslog`.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum Priority {
     /// System is unusable.


### PR DESCRIPTION
Priority is a trivial type to copy, so allow it for convenience.