### PR TITLE
Drop syn proc & quote dep & other id128 refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,26 +9,27 @@ description = "A pure-Rust client library to interact with systemd"
 keywords = ["systemd", "linux"]
 categories = ["api-bindings", "os::unix-apis"]
 readme = "README.md"
-exclude = [
-".gitignore",
-".travis.yml",
-]
+exclude = [".gitignore", ".travis.yml"]
 edition = "2018"
 
 [dependencies]
-hmac = "^0.11"
-libc = "^0.2"
-log = "^0.4"
-nix = "^0.22"
-serde = { version = "^1.0.91", features = ["derive"] }
-sha2 = "^0.9"
-thiserror = "^1.0"
-uuid = { version = "^0.8.1", features = ["serde"] }
+hmac = "0.11"
+libc = "0.2"
+log = "0.4"
+nix = "0.22"
+serde_crate = { package = "serde", version = "1.0.91" }
+sha2 = "0.9"
+uuid = { features = ["serde"], version = "0.8" }
 
 [dev-dependencies]
-quickcheck = "^1.0"
-serde_json = "^1.0"
-rand = "^0.8"
+quickcheck = "1.0"
+serde_json = "1.0"
+serde_test = "1.0"
+rand = "0.8"
+
+[features]
+# 0.4 make serde optional
+#serde = ["uuid/serde", "serde_crate"]
 
 [package.metadata.release]
 sign-commit = true

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,16 @@
-use thiserror::Error;
+use std::{error::Error, fmt};
 
 /// Library errors.
-#[derive(Error, Debug)]
-#[error("libsystemd error: {0}")]
+#[derive(Debug)]
 pub struct SdError(pub(crate) String);
+
+impl fmt::Display for SdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "libsystemd error: {}", self.0)
+    }
+}
+
+impl Error for SdError {}
 
 impl From<&str> for SdError {
     fn from(arg: &str) -> Self {


### PR DESCRIPTION
* Drop the syn, proc & quote deps by removing the `derive` feature from serde & manually impl Error instead of with thiserror
* Id128
  * deprecate `try_from_slice` in favour of `TryFrom<[u8]>`
  * deprecate `parse_str` in favor of `FromStr`
  * add `Id128::from_boot` method
  * deprecate `get_machine` in favor of `Id128::from_machine`
  * deprecate `get_machine_app_specific` since it goes against the rust API guidelines (users should call `Id128::from_machine()?.app_specific()` instead)
  * add `as_bytes` method
  * impl `AsRef<[u8]>`, `AsRef<OsStr>` & `From<[u8; 16]>`
  * added serde test
* change all deps versions from `^x.y.z` to `x.y.z` as cargo interprets them the same

This PR is to the best of my knowledge backwards compatible

Closes #78