### PR TITLE
sysusers: add parsing logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hmac = "^0.11"
 libc = "^0.2"
 log = "^0.4"
 nix = "^0.23"
+nom = "7"
 serde = { version = "^1.0.91", features = ["derive"] }
 sha2 = "^0.9"
 thiserror = "^1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,17 +2,33 @@ use thiserror::Error;
 
 /// Library errors.
 #[derive(Error, Debug)]
-#[error("libsystemd error: {0}")]
-pub struct SdError(pub(crate) String);
+#[error("libsystemd error: {msg}")]
+pub struct SdError {
+    pub(crate) kind: ErrorKind,
+    pub(crate) msg: String,
+}
 
 impl From<&str> for SdError {
     fn from(arg: &str) -> Self {
-        Self(arg.to_string())
+        Self {
+            kind: ErrorKind::Generic,
+            msg: arg.to_string(),
+        }
     }
 }
 
 impl From<String> for SdError {
     fn from(arg: String) -> Self {
-        Self(arg)
+        Self {
+            kind: ErrorKind::Generic,
+            msg: arg,
+        }
     }
+}
+
+/// Markers for recoverable error kinds.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ErrorKind {
+    Generic,
+    SysusersUnknownType,
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -146,8 +146,7 @@ where
     V: AsRef<str>,
 {
     let sock = SD_SOCK.get_or_try_init(|| {
-        UnixDatagram::unbound()
-            .map_err(|e| SdError(format!("failed to open datagram socket: {}", e)))
+        UnixDatagram::unbound().map_err(|e| format!("failed to open datagram socket: {}", e))
     })?;
 
     let mut data = Vec::new();
@@ -242,28 +241,28 @@ impl JournalStream {
     /// See also [`JournalStream::from_env()`] and [`JournalStream::from_env_default()`].
     pub fn parse<S: AsRef<OsStr>>(value: S) -> Result<Self, SdError> {
         let s = value.as_ref().to_str().ok_or_else(|| {
-            SdError(format!(
+            format!(
                 "Failed to parse journal stream: Value {:?} not UTF-8 encoded",
                 value.as_ref()
-            ))
+            )
         })?;
         let (device_s, inode_s) = s.find(':').map(|i| (&s[..i], &s[i + 1..])).ok_or_else(|| {
-            SdError(format!(
+            format!(
                 "Failed to parse journal stream: Missing separator ':' in value '{}'",
                 s
-            ))
+            )
         })?;
         let device = dev_t::from_str(device_s).map_err(|err| {
-            SdError(format!(
+            format!(
                 "Failed to parse journal stream: Device part is not a number '{}': {}",
                 device_s, err
-            ))
+            )
         })?;
         let inode = ino_t::from_str(inode_s).map_err(|err| {
-            SdError(format!(
+            format!(
                 "Failed to parse journal stream: Inode part is not a number '{}': {}",
                 inode_s, err
-            ))
+            )
         })?;
         Ok(JournalStream { device, inode })
     }
@@ -273,10 +272,10 @@ impl JournalStream {
     /// See [`JournalStream::parse()`] for more information.
     pub fn from_env<S: AsRef<OsStr>>(key: S) -> Result<Self, SdError> {
         Self::parse(std::env::var_os(&key).ok_or_else(|| {
-            SdError(format!(
+            format!(
                 "Failed to parse journal stream: Environment variable {:?} unset",
                 key.as_ref()
-            ))
+            )
         })?)
     }
 

--- a/src/sysusers/parse.rs
+++ b/src/sysusers/parse.rs
@@ -1,0 +1,246 @@
+use super::*;
+use nom::bytes::complete::{tag, take_while1};
+use nom::character::complete::{anychar, multispace0, multispace1};
+use nom::{Finish, IResult};
+use std::convert::TryInto;
+use std::str::FromStr;
+
+/// Parse `sysusers.d` configuration entries from a buffered reader.
+pub fn parse_from_reader(bufrd: &mut impl BufRead) -> Result<Vec<SysusersEntry>, SdError> {
+    let mut output = vec![];
+    for (index, item) in bufrd.lines().enumerate() {
+        let linenumber = index.saturating_add(1);
+        let line = item.map_err(|e| format!("failed to read line {}: {}", linenumber, e))?;
+
+        let data = line.trim();
+        // Skip empty lines and comments.
+        if data.is_empty() || data.starts_with('#') {
+            continue;
+        }
+
+        let entry: SysusersEntry = data.parse().map_err(|e: SdError| {
+            format!(
+                "failed to parse sysusers entry at line {}: {}",
+                linenumber, e.0
+            )
+        })?;
+
+        output.push(entry);
+    }
+
+    Ok(output)
+}
+
+impl FromStr for SysusersEntry {
+    type Err = SdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let input = s.trim();
+        match input.chars().next() {
+            Some('g') => CreateGroup::from_str(input).map(|v| v.into_sysusers_entry()),
+            Some('m') => AddUserToGroup::from_str(input).map(|v| v.into_sysusers_entry()),
+            Some('r') => AddRange::from_str(input).map(|v| v.into_sysusers_entry()),
+            Some('u') => CreateUserAndGroup::from_str(input).map(|v| v.into_sysusers_entry()),
+            _ => Err("unrecognized sysusers type".into()),
+        }
+    }
+}
+
+impl FromStr for AddRange {
+    type Err = SdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = parse_to_sysusers_data(s)?;
+        data.try_into()
+    }
+}
+
+impl FromStr for AddUserToGroup {
+    type Err = SdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = parse_to_sysusers_data(s)?;
+        data.try_into()
+    }
+}
+
+impl FromStr for CreateGroup {
+    type Err = SdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = parse_to_sysusers_data(s)?;
+        data.try_into()
+    }
+}
+
+impl FromStr for CreateUserAndGroup {
+    type Err = SdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = parse_to_sysusers_data(s)?;
+        data.try_into()
+    }
+}
+
+/// Parse the content of a sysusers entry as `SysusersData`.
+fn parse_to_sysusers_data(line: &str) -> Result<SysusersData, SdError> {
+    let (rest, data) = parse_line(line).finish().map_err(|e| {
+        format!(
+            "parsing failed due to '{}' at '{}'",
+            e.code.description(),
+            e.input
+        )
+    })?;
+    if !rest.is_empty() {
+        return Err(format!("invalid trailing data: '{}'", rest).into());
+    }
+    Ok(data)
+}
+
+fn parse_line(input: &str) -> IResult<&str, SysusersData> {
+    let rest = input;
+    let (rest, kind) = {
+        let (rest, kind) = anychar(rest)?;
+        let (rest, _) = multispace1(rest)?;
+        (rest, kind.to_string())
+    };
+    let (rest, name) = {
+        let (rest, name) = take_while1(|c: char| !c.is_ascii_whitespace())(rest)?;
+        let (rest, _) = multispace1(rest)?;
+        (rest, name.to_string())
+    };
+    let (rest, id) = {
+        let (rest, id) = take_while1(|c: char| !c.is_ascii_whitespace())(rest)?;
+        let (rest, _) = multispace0(rest)?;
+        (rest, id.to_string())
+    };
+    let (rest, gecos) = {
+        let (rest, gecos) = parse_opt_string(rest)?;
+        let (rest, _) = multispace0(rest)?;
+        (rest, gecos.map(|s| s.to_string()))
+    };
+    let (rest, home_dir) = {
+        let (rest, home_dir) = parse_opt_string(rest)?;
+        let (rest, _) = multispace0(rest)?;
+        (rest, home_dir.map(|s| s.to_string()))
+    };
+    let (rest, shell) = {
+        let (rest, shell) = parse_opt_string(rest)?;
+        let (rest, _) = multispace0(rest)?;
+        (rest, shell.map(|s| s.to_string()))
+    };
+
+    let data = SysusersData {
+        kind,
+        name,
+        id,
+        gecos,
+        home_dir,
+        shell,
+    };
+    Ok((rest, data))
+}
+
+fn parse_opt_string(input: &str) -> IResult<&str, Option<&str>> {
+    match input.chars().next() {
+        None => Ok((input, None)),
+        Some('"') => parse_quoted_string(input),
+        _ => parse_plain_string(input),
+    }
+}
+
+// XXX(lucab): should this account for inner escaped quotes?
+fn parse_quoted_string(input: &str) -> IResult<&str, Option<&str>> {
+    let rest = input;
+    let (rest, _) = tag("\"")(rest)?;
+    let (rest, txt) = take_while1(|c: char| c != '"')(rest)?;
+    let (rest, _) = tag("\"")(rest)?;
+    Ok((rest, Some(txt)))
+}
+
+fn parse_plain_string(input: &str) -> IResult<&str, Option<&str>> {
+    let rest = input;
+    let (rest, txt) = take_while1(|c: char| !c.is_ascii_whitespace())(rest)?;
+    Ok((rest, Some(txt)))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sysusers;
+
+    #[test]
+    fn test_type_g() {
+        {
+            let input = r#"g input - - - -"#;
+            let expected = CreateGroup::new("input".to_string()).unwrap();
+            let output: CreateGroup = input.parse().unwrap();
+            assert_eq!(output, expected);
+            let line = output.to_string();
+            assert_eq!(line, input);
+        }
+    }
+
+    #[test]
+    fn test_type_m() {
+        {
+            let input = r#"m _authd input - - -"#;
+            let expected = AddUserToGroup::new("_authd".to_string(), "input".to_string()).unwrap();
+            let output: AddUserToGroup = input.parse().unwrap();
+            assert_eq!(output, expected);
+            let line = output.to_string();
+            assert_eq!(line, input);
+        }
+    }
+
+    #[test]
+    fn test_type_r() {
+        {
+            let input = r#"r - 500-900 - - -"#;
+            let expected = AddRange::new(500, 900).unwrap();
+            let output: AddRange = input.parse().unwrap();
+            assert_eq!(output, expected);
+            let line = output.to_string();
+            assert_eq!(line, input);
+        }
+    }
+
+    #[test]
+    fn test_type_u() {
+        {
+            let input =
+                r#"u postgres - "Postgresql Database" /var/lib/pgsql /usr/libexec/postgresdb"#;
+            let expected = CreateUserAndGroup::new(
+                "postgres".to_string(),
+                "Postgresql Database".to_string(),
+                Some("/var/lib/pgsql".to_string().into()),
+                Some("/usr/libexec/postgresdb".to_string().into()),
+            )
+            .unwrap();
+            let output: CreateUserAndGroup = input.parse().unwrap();
+            assert_eq!(output, expected);
+            let line = output.to_string();
+            assert_eq!(line, input);
+        }
+    }
+
+    #[test]
+    fn test_parse_from_reader() {
+        let config_fragment = r#"
+#Type Name     ID             GECOS                 Home directory Shell
+u     httpd    404            "HTTP User"
+u     _authd   /usr/bin/authd "Authorization user"
+# Test comment
+u     postgres -              "Postgresql Database" /var/lib/pgsql /usr/libexec/postgresdb
+g     input    -              -
+
+m     _authd   input
+u     root     0              "Superuser"           /root          /bin/zsh
+r     -        500-900
+"#;
+
+        let mut reader = config_fragment.as_bytes();
+        let entries = sysusers::parse_from_reader(&mut reader).unwrap();
+        assert_eq!(entries.len(), 7);
+    }
+}

--- a/src/sysusers/serialization.rs
+++ b/src/sysusers/serialization.rs
@@ -1,7 +1,7 @@
 use super::*;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
-use std::convert::TryInto;
+use std::convert::TryFrom;
 
 /// Number of fields in each sysusers entry.
 const SYSUSERS_FIELDS: usize = 6;
@@ -72,7 +72,7 @@ impl TryFrom<SysusersData> for CreateGroup {
         ensure_field_none_or_automatic("Home directory", &value.home_dir)?;
         ensure_field_none_or_automatic("Shell", &value.shell)?;
 
-        let gid: GidOrPath = value.id.as_str().try_into()?;
+        let gid: GidOrPath = value.id.parse()?;
         Self::impl_new(value.name, gid)
     }
 }
@@ -85,7 +85,7 @@ impl TryFrom<SysusersData> for CreateUserAndGroup {
             return Err(format!("unexpected sysuser entry of type '{}'", value.kind).into());
         }
 
-        let id: IdOrPath = value.id.as_str().try_into()?;
+        let id: IdOrPath = value.id.parse()?;
         Self::impl_new(
             value.name,
             value.gecos.unwrap_or_default(),


### PR DESCRIPTION
This adds support for parsing entries from sysusers.d lines.
Overall logic is organized around the 'nom' parser-combinator
framework.
It is now possible to roundtrip configuration entries, loading
content from files as well as writing back data.