### PR TITLE
Add credential loader helper

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -1,0 +1,72 @@
+use std::{env, ffi::OsStr, fs, io, path::PathBuf};
+
+/// Credential loader for units.
+///
+/// Credentials are read by systemd on unit startup and exported by their ID.
+///
+/// **Note**: only the user associated with the unit and the superuser may access credentials.
+///
+/// More documentation: <https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Credentials>
+#[derive(Clone, Debug)]
+pub struct CredentialLoader {
+    dir: PathBuf,
+}
+
+impl CredentialLoader {
+    /// Attempt to initiate a loader, returning [`None`] if no credentials are available.
+    pub fn new() -> Option<Self> {
+        let dir: PathBuf = env::var_os("CREDENTIALS_DIRECTORY")?.into();
+
+        if dir.is_dir() {
+            Some(Self { dir })
+        } else {
+            None
+        }
+    }
+
+    /// Get a credential by its ID.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use libsystemd::CredentialLoader;
+    ///
+    /// if let Some(loader) = CredentialLoader::new() {
+    ///     let key = "token";
+    ///     match loader.get("token") {
+    ///         Ok(val) => println!("{}: {}", key, String::from_utf8_lossy(&val)),
+    ///         Err(e) => println!("couldn't retreive {}: {}", key, e),
+    ///     }
+    /// }
+    /// ```
+    pub fn get<K: AsRef<OsStr>>(&self, id: K) -> io::Result<Vec<u8>> {
+        self._get(id.as_ref())
+    }
+
+    fn _get(&self, id: &OsStr) -> io::Result<Vec<u8>> {
+        let path: PathBuf = [self.dir.as_ref(), id].iter().collect();
+
+        fs::read(path)
+    }
+
+    /// An iterator over this units credentials.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use libsystemd::CredentialLoader;
+    ///
+    /// if let Some(loader) = CredentialLoader::new() {
+    ///     for entry in loader.iter() {
+    ///         match entry {
+    ///             Ok(entry) => {
+    ///                 let key = entry.file_name();
+    ///                 println!("{:?}: {}", key, String::from_utf8_lossy(&loader.get(&key)?))
+    ///             }
+    ///             Err(e) => println!("couldn't list some credential: {}", e),
+    ///         }
+    ///     }
+    /// }
+    /// # Ok::<(), std::io::Error>(())
+    pub fn iter(&self) -> fs::ReadDir {
+        self.dir.read_dir().expect("path exists")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 
 /// Interfaces for socket-activated services.
 pub mod activation;
+mod credential;
 /// Interfaces for systemd-aware daemons.
 pub mod daemon;
 /// Error handling.
@@ -34,3 +35,5 @@ pub mod logging;
 pub mod sysusers;
 /// Helpers for working with systemd units.
 pub mod unit;
+
+pub use credential::CredentialLoader;


### PR DESCRIPTION
Not a part of the C `libsystemd` library but I don't know if being strictly 1-1 is a goal.

Although the code is simple I do feel that it'd be a waste for every application to reimplement it.