### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsystemd"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Luca Bruno <lucab@lucabruno.net>", "Sebastian Wiesner <sebastian@swsnr.de>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"


### PR DESCRIPTION
Changes:
 * cargo: update sha2 and hmac to new version
 * sysusers: introduce new module for 'sysusers.d' configuration fragments
 * sysusers: add parsing logic
 * sysusers: expose more field details
 * sysusers: add serialization support