### PR TITLE
id128: add get_boot() and get_boot_app_specific()

### DIFF
--- a/examples/id128.rs
+++ b/examples/id128.rs
@@ -1,0 +1,18 @@
+use libsystemd::id128;
+
+fn main() {
+    let app_id = id128::Id128::parse_str("47c2a52ec65947ae88b2b08d14ec126b")
+        .expect("Failed to parse ID string");
+
+    println!("get_machine:              {:?}", id128::get_machine());
+    println!(
+        "get_machine_app_specific: {:?}",
+        id128::get_machine_app_specific(&app_id)
+    );
+
+    println!("get_boot:                 {:?}", id128::get_boot());
+    println!(
+        "get_boot_app_specific:    {:?}",
+        id128::get_boot_app_specific(&app_id)
+    );
+}

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -105,6 +105,21 @@ pub fn get_machine_app_specific(app_id: &Id128) -> Result<Id128, SdError> {
     machine_id.app_specific(app_id)
 }
 
+/// Return the unique ID of this boot.
+pub fn get_boot() -> Result<Id128, SdError> {
+    let mut buf = String::new();
+    let mut fd = fs::File::open("/proc/sys/kernel/random/boot_id")
+        .map_err(|e| format!("failed to open boot_id: {}", e))?;
+    fd.read_to_string(&mut buf)
+        .map_err(|e| format!("failed to read boot_id: {}", e))?;
+    Id128::parse_str(buf.trim_end())
+}
+
+/// Return the unique ID of this boot, hashed with an application-specific ID.
+pub fn get_boot_app_specific(app_id: &Id128) -> Result<Id128, SdError> {
+    get_boot()?.app_specific(app_id)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Additionally add an example for the new and existing id128::get_*
functions.