### PR TITLE
logging: reduce the amount of allocations in hotpath

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -60,6 +60,21 @@ impl std::convert::From<Priority> for u8 {
     }
 }
 
+impl Priority {
+    fn as_str(&self) -> &str {
+        match self {
+            Priority::Emergency => "0",
+            Priority::Alert => "1",
+            Priority::Critical => "2",
+            Priority::Error => "3",
+            Priority::Warning => "4",
+            Priority::Notice => "5",
+            Priority::Info => "6",
+            Priority::Debug => "7",
+        }
+    }
+}
+
 #[inline(always)]
 fn is_valid_char(c: char) -> bool {
     c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'
@@ -103,11 +118,17 @@ fn is_valid_field(input: &str) -> bool {
 ///
 /// See <https://systemd.io/JOURNAL_NATIVE_PROTOCOL/> for details.
 fn add_field_and_payload_explicit_length(data: &mut Vec<u8>, field: &str, payload: &str) {
-    data.extend(field.as_bytes());
-    data.push(b'\n');
-    data.extend(&(payload.len() as u64).to_le_bytes());
-    data.extend(payload.as_bytes());
-    data.push(b'\n');
+    data.extend(
+        [
+            field.as_bytes(),
+            b"\n",
+            &(payload.len() as u64).to_le_bytes(),
+            payload.as_bytes(),
+            b"\n",
+        ]
+        .iter()
+        .flat_map(|x| x.iter()),
+    );
 }
 
 /// Add  a journal `field` and its `payload` to journal fields `data` with appropriate encoding.
@@ -124,10 +145,11 @@ fn add_field_and_payload(data: &mut Vec<u8>, field: &str, payload: &str) {
             add_field_and_payload_explicit_length(data, field, payload);
         } else {
             // If payload doesn't contain an newline directly write the field name and the payload
-            data.extend(field.as_bytes());
-            data.push(b'=');
-            data.extend(payload.as_bytes());
-            data.push(b'\n');
+            data.extend(
+                [field.as_bytes(), b"=", payload.as_bytes(), b"\n"]
+                    .iter()
+                    .flat_map(|x| x.iter()),
+            );
         }
     }
 }
@@ -149,7 +171,7 @@ where
         .context("failed to open datagram socket")?;
 
     let mut data = Vec::new();
-    add_field_and_payload(&mut data, "PRIORITY", &(u8::from(priority)).to_string());
+    add_field_and_payload(&mut data, "PRIORITY", priority.as_str());
     add_field_and_payload(&mut data, "MESSAGE", msg);
     for (ref k, ref v) in vars {
         if k.as_ref() != "PRIORITY" && k.as_ref() != "MESSAGE" {
@@ -339,6 +361,24 @@ mod tests {
                 );
                 false
             }
+        }
+    }
+
+    #[test]
+    fn test_priority_as_str_matches_to_string() {
+        let priorities = [
+            Priority::Emergency,
+            Priority::Alert,
+            Priority::Critical,
+            Priority::Error,
+            Priority::Warning,
+            Priority::Notice,
+            Priority::Info,
+            Priority::Debug,
+        ];
+
+        for priority in &priorities {
+            assert_eq!(&(u8::from(priority.clone())).to_string(), priority.as_str());
         }
     }
 


### PR DESCRIPTION
This removes the `to_string()` call on Priority by adding a private member function `numeric_level()`.  I've implemented the `numeric_level()` as a private member function to avoid adding to the API surface of Priority.  The provided test ensures that the function used internally and the representation publicly, via From<u8>, match.  Since rust does not have a small string optimization, this avoids an allocation for each call to `journal_send`.

This also adds a reserve call prior to adding data to the vector to avoid multiple allocations when extend and push are called, since the length of the data being added is fully known.