### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ harness = false
 [package.metadata.release]
 publish = false
 push = false
-post-release-commit-message = "cargo: development version bump"
 pre-release-commit-message = "cargo: libsystemd release {{version}}"
 sign-commit = true
 sign-tag = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsystemd"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Luca Bruno <lucab@lucabruno.net>", "Sebastian Wiesner <sebastian@swsnr.de>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"


### PR DESCRIPTION
Changes:
 * activation: fix build for compatibility with newer `nix` 
 * cargo: bump MSRV to 1.56
 * ci: update workflow
 * credentials: add helpers for accessing credential data
 * daemon/notify: add support for abstract Unix sockets
 * daemon/notify: add support for sending file descriptors
 * daemon/notify: sanity check state entries
 * errors: add internal helpers to simplify error handling
 * id128: add `get_boot()` and `get_boot_app_specific()`
 * logging: use std API to extract journal stream from FD
 * logging: fix `connected_to_journal` logic
 * logging: only check stderr for protocol upgrading 
 * logging: reduce the amount of allocations in hotpath
 * logging: un-export some JournalStream methods

Closes: https://github.com/lucab/libsystemd-rs/issues/124