### PR TITLE
logging: add comment about use of unconnected sockets

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -236,6 +236,11 @@ where
     //
     // Maximum data size is system dependent, thus this always tries the fast path and
     // falls back to the slow path if the former fails with `EMSGSIZE`.
+    //
+    // An unconnected socket client-side is used to cope with journald restarts.  The native systemd
+    // C library does the same.  See:
+    //  * https://github.com/coreos/go-systemd/pull/279.
+    //  * https://github.com/coreos/go-systemd/pull/218#issuecomment-274490875.
     match sock.send_to(&data, SD_JOURNAL_SOCK_PATH) {
         Ok(x) => Ok(x),
         // `EMSGSIZE` (errno code 90) means the message was too long for a UNIX socket,


### PR DESCRIPTION
This references some earlier discussion as to why connect is not used when setting up the socket used to write to the systemd journal. Looking at error reports, it seems as though most of the restarts to journald were due to watchdog timeouts when calling fsync under heavy I/O load.  This appears to be fixed in v230, however, the same rationale still holds; defensively specify the address each time instead of relying on journald to stay running.

See: https://www.suse.com/support/kb/doc/?id=000019921
