### PR TITLE
logging: remove unnecessary drop on memfd

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -287,9 +287,6 @@ fn send_memfd_payload(sock: &UnixDatagram, data: &[u8]) -> Result<usize, SdError
     )
     .context("sendmsg failed")?;
 
-    // Close our side of the memfd after we send it to systemd.
-    drop(memfd);
-
     Ok(data.len())
 }
 


### PR DESCRIPTION
This was added in #88, however, drop is already implicitly called on all objects when they go out of scope.  This, for memfd happens a couple lines later, so the drop is redundant.  The primary problem that #88 solved was changing `into_raw_fd()` to `as_raw_fd()`, which no longer transferred ownership, requiring a manual close.

From the [std::os::fd::IntoRawFd](https://doc.rust-lang.org/stable/std/os/fd/trait.IntoRawFd.html) docs:
> This function is typically used to transfer ownership of the underlying file descriptor to the caller. When used in this way, callers are then the unique owners of the file descriptor and must close it once it’s no longer needed.

It seems that the primary problem that close was not being called on memfd when it was consumed into a RawFd.