### PR TITLE
cargo: update MSRV to 1.65

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: '1.63.0'
+  ACTION_MSRV_TOOLCHAIN: '1.65.0'
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: '1.63.0'
+  ACTION_LINTS_TOOLCHAIN: '1.65.0'
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ".travis.yml",
 ]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 hmac = "^0.12"


### PR DESCRIPTION
This is required by our transitive dependencies (currently `regex-v1.10.2`).