### PR TITLE
cargo: libsystemd release 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsystemd"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Luca Bruno <lucab@lucabruno.net>", "Sebastian Wiesner <sebastian@swsnr.de>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"


### PR DESCRIPTION
Changes:
 * build(deps): update nix requirement from ^0.26 to ^0.27
 * cargo: update MSRV to 1.65
 * logging: fix build in armv7
 * logging: directly use memfd_create syscall
 * lib: fix IO safety
 * feat: Enhancing Id128 structure
 * logging: fix typo in connected_to_journal docs
 * logging: forgo validation of MESSAGE and PRIORITY fields at runtime
 * sysusers: internal Context helper to simplify error handling
 * id128: use internal Context helper to simplify error handling
 * daemon: use internal Context helper to simplify error handling
 * credentials: use internal Context helper to simplify error handling
 * activation: use internal Context helper to simplify error handling

Closes: https://github.com/lucab/libsystemd-rs/issues/147
