### PR TITLE
cargo: libsystemd release 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsystemd"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Luca Bruno <lucab@lucabruno.net>", "Sebastian Wiesner <sebastian@swsnr.de>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"


### PR DESCRIPTION
Changes:
 * activation: keep going on PID mismatch
 * cargo: update rand requirement from ^0.8 to ^0.9
 * cargo: update nom requirement from 7 to 8
 * cargo: update thiserror requirement from ^1.0 to ^2.0
 * cargo: update nix requirement from ^0.27 to ^0.28
 * ci: use MSRV from cargo manifest