### PR TITLE
cleanup: fix some Clippy warnings.

### DIFF
--- a/examples/persistent_state.rs
+++ b/examples/persistent_state.rs
@@ -55,6 +55,7 @@ fn create_and_store_persistent_state() -> Result<File, Box<dyn Error>> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&path)?;
     fs::remove_file(&path)?;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -26,8 +26,6 @@ static SD_SOCK: OnceCell<UnixDatagram> = OnceCell::new();
 const PRIORITY: ValidField = ValidField::unchecked("PRIORITY");
 const MESSAGE: ValidField = ValidField::unchecked("MESSAGE");
 
-/// Trait for checking the type of a file descriptor.
-
 /// Log priority values.
 ///
 /// See `man 3 syslog`.

--- a/src/sysusers/parse.rs
+++ b/src/sysusers/parse.rs
@@ -22,7 +22,7 @@ pub fn parse_from_reader(bufrd: &mut impl BufRead) -> Result<Vec<SysusersEntry>,
 
         match data.parse() {
             Ok(entry) => output.push(entry),
-            Err(SdError { kind, msg }) if kind == ErrorKind::SysusersUnknownType => {
+            Err(SdError { kind: ErrorKind::SysusersUnknownType, msg })  => {
                 log::warn!("skipped line {}: {}", linenumber, msg);
             }
             Err(e) => {

--- a/src/sysusers/parse.rs
+++ b/src/sysusers/parse.rs
@@ -22,7 +22,10 @@ pub fn parse_from_reader(bufrd: &mut impl BufRead) -> Result<Vec<SysusersEntry>,
 
         match data.parse() {
             Ok(entry) => output.push(entry),
-            Err(SdError { kind: ErrorKind::SysusersUnknownType, msg })  => {
+            Err(SdError {
+                kind: ErrorKind::SysusersUnknownType,
+                msg,
+            }) => {
                 log::warn!("skipped line {}: {}", linenumber, msg);
             }
             Err(e) => {

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -46,7 +46,7 @@ fn retry<T, E>(f: impl Fn() -> Result<T, E>) -> Result<T, E> {
 fn read_from_journal(test_name: &str) -> Vec<HashMap<String, String>> {
     let stdout = String::from_utf8(
         Command::new("journalctl")
-            .args(&["--user", "--output=json"])
+            .args(["--user", "--output=json"])
             // Filter by the PID of the current test process
             .arg(format!("_PID={}", std::process::id()))
             .arg(format!("TEST_NAME={}", test_name))

--- a/tests/persistent_state.rs
+++ b/tests/persistent_state.rs
@@ -17,6 +17,7 @@ fn create_and_store_persistent_state() -> Result<File, Box<dyn Error>> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&path)?;
     fs::remove_file(&path)?;
 


### PR DESCRIPTION
- Remove a stray doc comment.
- Match a pattern rather than using `if x == y`.
- Explicitly truncate newly-created files in tests/examples.
- Remove an unnecessary & in a test.

---

Some minor things I noticed and decided to eliminate in the name of getting rid of squiggly underlines and probably code health too I guess.