### PR TITLE
cargo: libsystemd release 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsystemd"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Luca Bruno <lucab@lucabruno.net>", "Sebastian Wiesner <sebastian@swsnr.de>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/libsystemd-rs"


### PR DESCRIPTION
Changes:
 * activation: Set FD_CLOEXEC on the fds we receive
 * cleanup: fix some clippy warnings