### PR TITLE
cargo: bump MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: '1.88.0'
+  ACTION_LINTS_TOOLCHAIN: '1.96.0'
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ".travis.yml",
 ]
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.85"
 
 [dependencies]
 hmac = "^0.12"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -400,9 +400,14 @@ impl From<FileStat> for JournalStream {
 ///
 /// [1]: https://systemd.io/JOURNAL_NATIVE_PROTOCOL/#automatic-protocol-upgrading
 pub fn connected_to_journal() -> bool {
-    JournalStream::from_env().map_or(false, |env_stream| {
-        JournalStream::from_fd(std::io::stderr()).map_or(false, |o| o == env_stream)
-    })
+    let Ok(stream) = JournalStream::from_env() else {
+        return false;
+    };
+    let Ok(stderr_fd) = JournalStream::from_fd(std::io::stderr()) else {
+        return false;
+    };
+
+    stderr_fd == stream
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This bumps MSRV to fix CI, and also updates linting toolchain to latest stable.